### PR TITLE
feat(step):  by updating to kronos-adapter-inbound-http to version 3.4.0 we can bind several routes to one endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/Kronos-Integration/kronos-http-routing-step#readme",
   "dependencies": {
     "koa-route": "^3.0.0",
-    "kronos-adapter-inbound-http": "^3.3.0",
+    "kronos-adapter-inbound-http": "^3.4.0",
     "kronos-step": "^2.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
http://greenkeeper.io/